### PR TITLE
Fixed logout for HCD

### DIFF
--- a/src/boot/api.js
+++ b/src/boot/api.js
@@ -10,7 +10,6 @@ import { AfloatApi } from '@jmgayosso/afloat-client'
 
 // const { NbvStorageApi } = require('../../../nbv-client-api')
 import { NbvStorageApi } from '@jmgayosso/nbv-client-api'
-
 // const { AfloatApi } = require('../../../afloat-client-api')
 export default async ({ app, store }) => {
   try {

--- a/src/layouts/ConfidentialDocsLayout.vue
+++ b/src/layouts/ConfidentialDocsLayout.vue
@@ -200,10 +200,14 @@ export default defineComponent({
     })
 
     async function logout () {
+      // eslint-disable-next-line no-undef
+      google.accounts.id.disableAutoSelect()
       $store.dispatch('hcdWallet/logout')
       $store.dispatch('polkadotWallet/hashedLogout')
-      await $router.push({ name: 'login' })
       $store.commit('profile/cleanProfile')
+      $store.$hcd.logout()
+
+      await $router.push({ name: 'login' })
     }
 
     function onSelectAccount (account) {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -113,7 +113,9 @@ export default defineComponent({
     })
 
     function logout () {
+      console.log('logout test')
       $store.dispatch('polkadotWallet/hashedLogout')
+      $store.$hcd.logout()
     }
 
     function onSelectAccount (account) {

--- a/src/services/confidential-docs/confidential-docs.js
+++ b/src/services/confidential-docs/confidential-docs.js
@@ -7,7 +7,7 @@ import {
   Polkadot,
   HashedFaucet
 } from '@smontero/hashed-confidential-docs'
-// } = require('../../../../hashed-confidential-docs-client-api/src/index')
+// = require('../../../../hashed-confidential-docs-client-api/src/index')
 
 class ConfidentialDocs {
   constructor ({ ipfsURL, chainURI, appName, faucetServerUrl, ipfsAuthHeader }) {


### PR DESCRIPTION
🔥 refactor(confidential-docs.js): remove commented out import statement
✨ feat(ConfidentialDocsLayout.vue): add call to google.accounts.id.disableAutoSelect() before logout to disable auto account selection
✨ feat(MainLayout.vue): add console.log statement to logout function for testing purposes